### PR TITLE
feat(products): add image reorder endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/Kris1027/nestjs-ecommerce-api/actions/workflows/ci.yml/badge.svg)](https://github.com/Kris1027/nestjs-ecommerce-api/actions/workflows/ci.yml)
 
-A production-ready **single-vendor ecommerce REST API** built with NestJS 11, TypeScript 5.9, Prisma 7, and PostgreSQL. Features JWT authentication with token rotation, Stripe payments with webhook processing, Cloudinary image uploads, BullMQ background jobs, and 98 fully documented API endpoints.
+A production-ready **single-vendor ecommerce REST API** built with NestJS 11, TypeScript 5.9, Prisma 7, and PostgreSQL. Features JWT authentication with token rotation, Stripe payments with webhook processing, Cloudinary image uploads, BullMQ background jobs, and 99 fully documented API endpoints.
 
 ---
 
@@ -19,8 +19,8 @@ A production-ready **single-vendor ecommerce REST API** built with NestJS 11, Ty
 | **Caching**        | Redis + cache-manager (Keyv adapter)        |
 | **Queue**          | BullMQ + Redis (background jobs)            |
 | **Validation**     | Zod 4 + nestjs-zod                          |
-| **Documentation**  | Swagger/OpenAPI (98 endpoints)              |
-| **Testing**        | Jest 30 (45 unit suites, 5 E2E suites, 690 tests) |
+| **Documentation**  | Swagger/OpenAPI (99 endpoints)              |
+| **Testing**        | Jest 30 (45 unit suites, 5 E2E suites, 694 tests) |
 | **Containerization** | Docker + Docker Compose                   |
 | **CI/CD**          | GitHub Actions (security, lint, typecheck, test, build) |
 | **Hosting**        | Railway (staging + production environments) |
@@ -343,7 +343,7 @@ The Docker Compose setup includes:
 
 ## API Documentation
 
-Swagger UI is available at **`/docs`** in non-production environments (98 documented endpoints). All API paths are prefixed with `/api/v1`.
+Swagger UI is available at **`/docs`** in non-production environments (99 documented endpoints). All API paths are prefixed with `/api/v1`.
 
 Additional export formats:
 - JSON: `/docs-json`
@@ -394,7 +394,7 @@ pnpm test -- --testPathPattern=auth.service
 pnpm test:cov
 ```
 
-- **45 test suites** with **690 unit tests**
+- **45 test suites** with **694 unit tests**
 - Services, controllers, guards, filters, interceptors, and event listeners all tested
 - Dependencies mocked via custom factories (`createMockPrismaClient`, Stripe, Cloudinary, BullMQ)
 - Coverage thresholds enforced: 80% lines/functions, 70% branches
@@ -449,7 +449,7 @@ GitHub Actions runs **5 parallel jobs** on every PR and push to main:
 | -------------- | ------- | --------------------------------------------------- |
 | **Security**   | 5 min   | Dependency vulnerability scanning (`pnpm audit`)    |
 | **Lint**       | 5 min   | ESLint checks + TypeScript typecheck                |
-| **Test**       | 10 min  | 690 unit tests with coverage threshold enforcement  |
+| **Test**       | 10 min  | 694 unit tests with coverage threshold enforcement  |
 | **Build**      | 5 min   | TypeScript compilation (type safety)                |
 | **Docker**     | 10 min  | Build production Docker image (same as Railway)     |
 

--- a/src/modules/products/dto/index.ts
+++ b/src/modules/products/dto/index.ts
@@ -2,4 +2,5 @@ export { CreateProductDto } from './create-product.dto';
 export { UpdateProductDto } from './update-product.dto';
 export { ProductQueryDto, type ProductQuery } from './product-query.dto';
 export { UploadImageDto } from './upload-image.dto';
+export { ReorderImagesDto } from './reorder-images.dto';
 export { ProductListItemDto, ProductDetailDto, ProductImageDto } from './product-response.dto';

--- a/src/modules/products/dto/reorder-images.dto.ts
+++ b/src/modules/products/dto/reorder-images.dto.ts
@@ -1,0 +1,8 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+const reorderImagesSchema = z.object({
+  imageIds: z.array(z.string().cuid()).nonempty('At least one image ID is required'),
+});
+
+export class ReorderImagesDto extends createZodDto(reorderImagesSchema) {}

--- a/src/modules/products/products.controller.spec.ts
+++ b/src/modules/products/products.controller.spec.ts
@@ -12,6 +12,7 @@ function createMockProductsService(): Record<keyof ProductsService, jest.Mock> {
     hardDelete: jest.fn(),
     addImage: jest.fn(),
     uploadImage: jest.fn(),
+    reorderImages: jest.fn(),
     removeImage: jest.fn(),
   };
 }

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -31,6 +31,7 @@ import {
   UpdateProductDto,
   ProductQueryDto,
   UploadImageDto,
+  ReorderImagesDto,
   ProductListItemDto,
   ProductDetailDto,
   ProductImageDto,
@@ -253,6 +254,20 @@ export class ProductsController {
     file: Express.Multer.File,
   ): ReturnType<ProductsService['uploadImage']> {
     return this.productsService.uploadImage(productId, file, dto.alt);
+  }
+
+  @Patch(':id/images/reorder')
+  @Roles('ADMIN')
+  @ApiBearerAuth('access-token')
+  @ApiOperation({ summary: 'Reorder product images (admin)' })
+  @ApiParam({ name: 'id', description: 'Product CUID' })
+  @ApiSuccessResponse(ProductDetailDto, 200, 'Images reordered')
+  @ApiErrorResponses(400, 401, 403, 404)
+  reorderImages(
+    @Param('id') productId: string,
+    @Body() dto: ReorderImagesDto,
+  ): ReturnType<ProductsService['reorderImages']> {
+    return this.productsService.reorderImages(productId, dto.imageIds);
   }
 
   @Delete(':id/images/:imageId')

--- a/src/modules/products/products.service.spec.ts
+++ b/src/modules/products/products.service.spec.ts
@@ -749,6 +749,73 @@ describe('ProductsService', () => {
     });
   });
 
+  describe('reorderImages', () => {
+    const imageA = 'climg1111111111111111111';
+    const imageB = 'climg2222222222222222222';
+    const imageC = 'climg3333333333333333333';
+
+    it('should update sortOrder for all images and emit cache event', async () => {
+      prisma.product.findUnique
+        .mockResolvedValueOnce({
+          id: mockProduct.id,
+          images: [{ id: imageA }, { id: imageB }, { id: imageC }],
+        })
+        .mockResolvedValueOnce(mockProduct); // findById after reorder
+      prisma.$transaction.mockResolvedValue([]);
+
+      const result = await service.reorderImages(mockProduct.id, [imageC, imageA, imageB]);
+
+      expect(result).toEqual(mockProduct);
+      expect(prisma.$transaction).toHaveBeenCalledWith([
+        prisma.productImage.update({ where: { id: imageC }, data: { sortOrder: 0 } }),
+        prisma.productImage.update({ where: { id: imageA }, data: { sortOrder: 1 } }),
+        prisma.productImage.update({ where: { id: imageB }, data: { sortOrder: 2 } }),
+      ]);
+      expect(eventEmitter.emitAsync).toHaveBeenCalledWith(
+        CacheEvents.PRODUCT_CHANGED,
+        expect.objectContaining({ productId: mockProduct.id, action: 'image_change' }),
+      );
+    });
+
+    it('should throw NotFoundException when product does not exist', async () => {
+      prisma.product.findUnique.mockResolvedValue(null);
+
+      await expect(service.reorderImages('nonexistent', [imageA])).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when imageIds count does not match', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: mockProduct.id,
+        images: [{ id: imageA }, { id: imageB }],
+      });
+
+      await expect(service.reorderImages(mockProduct.id, [imageA])).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('should throw BadRequestException when an imageId does not belong to the product', async () => {
+      prisma.product.findUnique.mockResolvedValue({
+        id: mockProduct.id,
+        images: [{ id: imageA }, { id: imageB }],
+      });
+
+      const foreignId = 'climg9999999999999999999';
+
+      await expect(service.reorderImages(mockProduct.id, [imageA, foreignId])).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
   describe('removeImage', () => {
     it('should remove image and cleanup cloudinary', async () => {
       prisma.productImage.findUnique.mockResolvedValue({

--- a/src/modules/products/products.service.ts
+++ b/src/modules/products/products.service.ts
@@ -619,6 +619,48 @@ export class ProductsService {
     return this.findById(productId);
   }
 
+  async reorderImages(productId: string, imageIds: string[]): Promise<ProductDetail> {
+    const product = await this.prisma.product.findUnique({
+      where: { id: productId },
+      select: {
+        id: true,
+        images: { select: { id: true } },
+      },
+    });
+
+    if (!product) {
+      throw new NotFoundException('Product not found');
+    }
+
+    const existingIds = new Set(product.images.map((img) => img.id));
+
+    if (imageIds.length !== existingIds.size) {
+      throw new BadRequestException('imageIds must contain exactly all image IDs for this product');
+    }
+
+    for (const id of imageIds) {
+      if (!existingIds.has(id)) {
+        throw new BadRequestException(`Image ${id} does not belong to this product`);
+      }
+    }
+
+    await this.prisma.$transaction(
+      imageIds.map((id, index) =>
+        this.prisma.productImage.update({
+          where: { id },
+          data: { sortOrder: index },
+        }),
+      ),
+    );
+
+    await this.eventEmitter.emitAsync(
+      CacheEvents.PRODUCT_CHANGED,
+      new ProductChangedEvent(productId, 'image_change'),
+    );
+
+    return this.findById(productId);
+  }
+
   // Helper for admin - get by ID (includes inactive)
   private async findById(id: string): Promise<ProductDetail> {
     const product = await this.prisma.product.findUnique({


### PR DESCRIPTION
## Summary
- Add `PATCH /api/v1/products/:id/images/reorder` endpoint for admin drag-to-reorder support
- Accepts ordered array of image CUIDs; index becomes new `sortOrder`
- Validates all IDs belong to the product, uses `$transaction` for atomic update
- Emits `PRODUCT_CHANGED` cache event after reorder

Closes #99